### PR TITLE
Allow utf-8 in resource_formats.json (issue #6054)

### DIFF
--- a/ckan/lib/helpers.py
+++ b/ckan/lib/helpers.py
@@ -2735,9 +2735,9 @@ def resource_formats():
                 os.path.dirname(os.path.realpath(ckan.config.__file__)),
                 'resource_formats.json'
             )
-        with open(format_file_path) as format_file:
+        with open(format_file_path, encoding='utf-8') as format_file:
             try:
-                file_resource_formats = json.loads(format_file.read())
+                file_resource_formats = json.loads(format_file.read(), )
             except ValueError as e:
                 # includes simplejson.decoder.JSONDecodeError
                 raise ValueError('Invalid JSON syntax in %s: %s' %


### PR DESCRIPTION
See https://github.com/ckan/ckan/issues/6054

Fixes #6054

### Proposed fixes:

Set encoding to utf8 for resource_formats.json

### Features:

- [ ] includes tests covering changes
- [ ] includes updated documentation
- [ ] includes user-visible changes
- [ ] includes API changes
- [ ] includes bugfix for possible backport

Please [X] all the boxes above that apply
